### PR TITLE
feat: nested sub-invocation support for mock and real auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,6 +1440,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-features-contract"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+ "soroban-sdk-tools",
+]
+
+[[package]]
 name = "soroban-ledger-snapshot"
 version = "25.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "soroban-sdk-tools",
     "soroban-sdk-tools-macro",
     "examples/*/Cargo.toml",
+    "examples/features",
     "examples/errors/*",
     "examples/auth/*",
 ]

--- a/justfile
+++ b/justfile
@@ -9,6 +9,7 @@ path:
 
 # build contracts
 build:
+    just _build soroban-features-contract
     just _build soroban-errors-calc-contract
     just _build soroban-errors-external-contract
     just _build soroban-errors-contract

--- a/soroban-sdk-tools/src/auth/builder.rs
+++ b/soroban-sdk-tools/src/auth/builder.rs
@@ -147,6 +147,7 @@ pub struct CallBuilder<'a, R, TryR = ()> {
     signers: StdVec<&'a dyn Signer>,
     invoker: Box<dyn FnOnce() -> R + 'a>,
     try_invoker: Option<Box<dyn FnOnce() -> TryR + 'a>>,
+    sub_invokes: StdVec<MockAuthInvoke<'a>>,
 }
 
 impl<'a, R, TryR> CallBuilder<'a, R, TryR> {
@@ -170,6 +171,7 @@ impl<'a, R, TryR> CallBuilder<'a, R, TryR> {
             signers: StdVec::new(),
             invoker,
             try_invoker,
+            sub_invokes: StdVec::new(),
         }
     }
 
@@ -225,14 +227,16 @@ impl<'a, R, TryR> CallBuilder<'a, R, TryR> {
         self
     }
 
-    fn run_auth_setup(
-        env: &Env,
-        contract: &Address,
-        fn_name: &str,
-        args: Vec<Val>,
-        signers: &[&dyn Signer],
-        authorizers: &[&Address],
-    ) {
+    fn run_auth_setup(&self) {
+        let Self {
+            env,
+            contract,
+            fn_name,
+            args,
+            authorizers,
+            signers,
+            ..
+        } = &self;
         if !signers.is_empty() && !authorizers.is_empty() {
             panic!("cannot mix .sign() and .authorize() on the same CallBuilder");
         }
@@ -240,7 +244,7 @@ impl<'a, R, TryR> CallBuilder<'a, R, TryR> {
         if !signers.is_empty() {
             setup_real_auth(env, contract, fn_name, args, signers);
         } else {
-            setup_mock_auth(env, contract, fn_name, args, authorizers);
+            setup_mock_auth(env, authorizers, self.mock_auth_invocation());
         }
     }
 
@@ -250,14 +254,7 @@ impl<'a, R, TryR> CallBuilder<'a, R, TryR> {
     /// If authorizers are configured, uses mock auth.
     /// Panics if both are configured.
     pub fn invoke(self) -> R {
-        Self::run_auth_setup(
-            self.env,
-            self.contract,
-            self.fn_name,
-            self.args,
-            &self.signers,
-            &self.authorizers,
-        );
+        self.run_auth_setup();
         (self.invoker)()
     }
 
@@ -271,19 +268,40 @@ impl<'a, R, TryR> CallBuilder<'a, R, TryR> {
     /// Panics if no try invoker was provided (i.e. the `CallBuilder` was not
     /// constructed by a generated `AuthClient` method).
     pub fn try_invoke(self) -> TryR {
-        Self::run_auth_setup(
-            self.env,
-            self.contract,
-            self.fn_name,
-            self.args,
-            &self.signers,
-            &self.authorizers,
-        );
+        self.run_auth_setup();
         let try_invoker = self
             .try_invoker
             .expect("try_invoker not set; use try_invoke through AuthClient methods");
         (try_invoker)()
     }
+
+    pub fn add_sub_invoke<B: AsMockAuthInvoke<'a>>(mut self, builder: &'a B) -> Self {
+        self.sub_invokes.push(builder.mock_auth_invocation());
+        self
+    }
+}
+
+impl<'a, R, TryR> AsMockAuthInvoke<'a> for CallBuilder<'a, R, TryR> {
+    fn mock_auth_invocation(&self) -> MockAuthInvoke {
+        let Self {
+            contract,
+            fn_name,
+            args,
+            sub_invokes,
+            ..
+        } = &self;
+        let args = args.into_val(self.env);
+        MockAuthInvoke {
+            contract,
+            fn_name,
+            args,
+            sub_invokes,
+        }
+    }
+}
+
+pub trait AsMockAuthInvoke<'a> {
+    fn mock_auth_invocation(&'a self) -> MockAuthInvoke<'a>;
 }
 
 // ===========================================================================
@@ -315,32 +333,13 @@ impl<'a, R, TryR> CallBuilder<'a, R, TryR> {
 ///     &[from.clone()],
 /// );
 /// ```
-pub fn setup_mock_auth<A>(
-    env: &Env,
-    contract: &Address,
-    fn_name: &str,
-    args: A,
-    authorizers: &[&Address],
-) where
-    A: IntoVal<Env, Vec<Val>>,
-{
+pub fn setup_mock_auth<'a>(env: &Env, authorizers: &[&Address], invoke: MockAuthInvoke<'a>) {
     // If no authorizers specified, clear any prior mock auth state
     // (e.g. mock_all_auths) so calls run with no authorization.
     if authorizers.is_empty() {
         env.mock_auths(&[]);
         return;
     }
-
-    // Convert args to Vec<Val>
-    let args_val: Vec<Val> = args.into_val(env);
-
-    // Create the shared MockAuthInvoke that all authorizers will reference
-    let invoke = MockAuthInvoke {
-        contract,
-        fn_name,
-        args: args_val,
-        sub_invokes: &[],
-    };
 
     // Build MockAuth entries for each authorizer
     // Each authorizer gets a separate MockAuth entry for the same invocation

--- a/soroban-sdk-tools/src/auth/builder.rs
+++ b/soroban-sdk-tools/src/auth/builder.rs
@@ -272,7 +272,7 @@ impl<'a, R, TryR> CallBuilder<'a, R, TryR> {
 }
 
 impl<'a, R, TryR> AsMockAuthInvoke<'a> for CallBuilder<'a, R, TryR> {
-    fn mock_auth_invocation(&self) -> MockAuthInvoke {
+    fn mock_auth_invocation(&self) -> MockAuthInvoke<'_> {
         let Self {
             contract,
             fn_name,

--- a/soroban-sdk-tools/src/auth/builder.rs
+++ b/soroban-sdk-tools/src/auth/builder.rs
@@ -24,49 +24,49 @@ std::thread_local! {
     static NONCE_COUNTER: Cell<i64> = const { Cell::new(0) };
 }
 
-/// Build and register real (cryptographically signed) authorization entries.
-///
-/// For each signer, this constructs a `SorobanAuthorizationEntry` with
-/// proper `SorobanCredentials::Address` containing a real signature over the
-/// authorization payload hash.
-///
-/// # Arguments
-///
-/// * `env` - The Soroban environment
-/// * `contract` - The contract address being called
-/// * `fn_name` - The function name being invoked
-/// * `args` - The function arguments
-/// * `signers` - The signers that will authorize this invocation
-pub fn setup_real_auth<A>(
-    env: &Env,
-    contract: &Address,
-    fn_name: &str,
-    args: A,
-    signers: &[&dyn Signer],
-) where
-    A: IntoVal<Env, Vec<Val>>,
-{
-    if signers.is_empty() {
-        return;
-    }
-
-    let args_val: Vec<Val> = args.into_val(env);
-    // Convert soroban_sdk::Vec<Val> to xdr vec of ScVal
+/// Convert a [`MockAuthInvoke`] tree into a [`SorobanAuthorizedInvocation`]
+/// XDR structure, recursively converting all sub-invocations.
+fn mock_invoke_to_xdr(env: &Env, invoke: &MockAuthInvoke) -> SorobanAuthorizedInvocation {
     let mut xdr_args: StdVec<ScVal> = StdVec::new();
-    for i in 0..args_val.len() {
-        let val: Val = args_val.get(i).unwrap();
+    for i in 0..invoke.args.len() {
+        let val: Val = invoke.args.get(i).unwrap();
         let sc_val = ScVal::try_from_val(env, &val).unwrap();
         xdr_args.push(sc_val);
     }
 
-    let root_invocation = SorobanAuthorizedInvocation {
+    let sub_invocations: StdVec<SorobanAuthorizedInvocation> = invoke
+        .sub_invokes
+        .iter()
+        .map(|sub| mock_invoke_to_xdr(env, sub))
+        .collect();
+
+    SorobanAuthorizedInvocation {
         function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
-            contract_address: ScAddress::from(contract),
-            function_name: ScSymbol(fn_name.try_into().unwrap()),
+            contract_address: ScAddress::from(invoke.contract),
+            function_name: ScSymbol(invoke.fn_name.try_into().unwrap()),
             args: xdr_args.try_into().unwrap(),
         }),
-        sub_invocations: Default::default(),
-    };
+        sub_invocations: sub_invocations.try_into().unwrap(),
+    }
+}
+
+/// Build and register real (cryptographically signed) authorization entries.
+///
+/// For each signer, this constructs a `SorobanAuthorizationEntry` with
+/// proper `SorobanCredentials::Address` containing a real signature over the
+/// authorization payload hash, including any nested sub-invocations.
+///
+/// # Arguments
+///
+/// * `env` - The Soroban environment
+/// * `signers` - The signers that will authorize this invocation
+/// * `invoke` - The invocation tree (root + sub-invocations) to sign
+pub fn setup_real_auth<'a>(env: &Env, signers: &[&dyn Signer], invoke: MockAuthInvoke<'a>) {
+    if signers.is_empty() {
+        return;
+    }
+
+    let root_invocation = mock_invoke_to_xdr(env, &invoke);
 
     let curr_ledger = env.ledger().sequence();
     let max_ttl = env.storage().max_ttl();
@@ -90,7 +90,6 @@ pub fn setup_real_auth<A>(
             invocation: root_invocation.clone(),
         });
 
-        // Serialize and hash the preimage
         let mut buf = StdVec::<u8>::new();
         preimage
             .write_xdr(&mut Limited::new(&mut buf, Limits::none()))
@@ -228,23 +227,14 @@ impl<'a, R, TryR> CallBuilder<'a, R, TryR> {
     }
 
     fn run_auth_setup(&self) {
-        let Self {
-            env,
-            contract,
-            fn_name,
-            args,
-            authorizers,
-            signers,
-            ..
-        } = &self;
-        if !signers.is_empty() && !authorizers.is_empty() {
+        if !self.signers.is_empty() && !self.authorizers.is_empty() {
             panic!("cannot mix .sign() and .authorize() on the same CallBuilder");
         }
 
-        if !signers.is_empty() {
-            setup_real_auth(env, contract, fn_name, args, signers);
+        if !self.signers.is_empty() {
+            setup_real_auth(self.env, &self.signers, self.mock_auth_invocation());
         } else {
-            setup_mock_auth(env, authorizers, self.mock_auth_invocation());
+            setup_mock_auth(self.env, &self.authorizers, self.mock_auth_invocation());
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `sub_invokes` field to `CallBuilder` and `add_sub_invoke()` method for composing nested auth trees
- Refactor `setup_real_auth` to accept `MockAuthInvoke` (matching `setup_mock_auth`), with recursive XDR conversion of sub-invocations via `mock_invoke_to_xdr`
- Unify `run_auth_setup` so both mock and real auth paths use `mock_auth_invocation()`
- Update all existing test call sites to the new API signatures

## Test plan
- [x] Mock auth with single-level sub-invocations
- [x] Real auth (Ed25519) with single-level sub-invocations
- [x] Mock auth with 3-level deep nesting
- [x] Real auth with 3-level deep nesting
- [x] `CallBuilder.add_sub_invoke()` with mock auth
- [x] `CallBuilder.add_sub_invoke()` with real auth
- [x] Missing sub-invocation panics (both mock and real)
- [x] All 211 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)