### PR TITLE
fix: update tests for new auth API and __constructor

### DIFF
--- a/examples/features/src/test.rs
+++ b/examples/features/src/test.rs
@@ -5,6 +5,18 @@ use soroban_sdk::{
     Address, Bytes, BytesN, Env, IntoVal, String, Symbol, TryFromVal, Val, Vec as HostVec,
 };
 
+// Helper to register the FeaturesContract with default Token/TKN metadata.
+fn register_default<'a>(env: &'a Env, admin: &Address) -> Address {
+    env.register(
+        FeaturesContract,
+        (
+            admin,
+            String::from_str(env, "Token"),
+            String::from_str(env, "TKN"),
+        ),
+    )
+}
+
 // ============================================================================
 // Initialization Tests - Instance Storage
 // ============================================================================
@@ -14,17 +26,14 @@ fn test_initialization() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let name = String::from_str(env, "Test Token");
     let symbol = String::from_str(env, "TST");
 
-    // Initialize contract
-    client.init(&admin, &name, &symbol);
+    let contract_id = env.register(FeaturesContract, (&admin, name.clone(), symbol.clone()));
+    let client = FeaturesContractClient::new(env, &contract_id);
 
-    // Verify instance data
+    // Verify instance data set by __constructor
     assert_eq!(client.get_admin(), Some(admin));
     assert!(client.is_enabled());
     assert_eq!(client.get_metadata(&String::from_str(env, "name")), Some(name));
@@ -33,25 +42,6 @@ fn test_initialization() {
         Some(symbol)
     );
     assert_eq!(client.get_total_supply(), 0);
-}
-
-#[test]
-fn test_already_initialized_error() {
-    let env = &Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
-    let admin = Address::generate(env);
-    let name = String::from_str(env, "Test Token");
-    let symbol = String::from_str(env, "TST");
-
-    client.init(&admin, &name, &symbol);
-
-    // Second initialization should fail
-    let result = client.try_init(&admin, &name, &symbol);
-    assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
 }
 
 // ============================================================================
@@ -63,15 +53,9 @@ fn test_metadata_operations() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     // Add metadata
     let key = String::from_str(env, "website");
@@ -98,17 +82,11 @@ fn test_mint_and_balance() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let user = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     // Mint tokens
     client.mint(&user, &1000);
@@ -126,18 +104,12 @@ fn test_transfer() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let from = Address::generate(env);
     let to = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     // Mint to sender
     client.mint(&from, &1000);
@@ -155,18 +127,12 @@ fn test_transfer_insufficient_balance() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let from = Address::generate(env);
     let to = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     client.mint(&from, &100);
 
@@ -184,19 +150,13 @@ fn test_approve_and_transfer_from() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let owner = Address::generate(env);
     let spender = Address::generate(env);
     let recipient = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     // Mint to owner
     client.mint(&owner, &1000);
@@ -219,19 +179,13 @@ fn test_transfer_from_insufficient_allowance() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let owner = Address::generate(env);
     let spender = Address::generate(env);
     let recipient = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     client.mint(&owner, &1000);
 
@@ -249,17 +203,11 @@ fn test_freeze_account() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let user = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     client.mint(&user, &1000);
 
@@ -292,15 +240,9 @@ fn test_governance_events() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     // Record events
     client.record_event(&1, &String::from_str(env, "Contract deployed"));
@@ -322,17 +264,11 @@ fn test_proposals() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let proposer = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     // Create proposal
     client.create_proposal(&1, &proposer);
@@ -348,17 +284,11 @@ fn test_faucet_rate_limiting() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let user = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     // First faucet claim succeeds
     client.faucet(&user);
@@ -386,16 +316,10 @@ fn test_faucet_when_paused() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     // Pause contract
     client.set_metadata(&String::from_str(env, "paused"), &String::from_str(env, "true"));
@@ -413,17 +337,11 @@ fn test_advanced_operation() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let user = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     // Call advanced operation
     client.advanced_operation(&user, &999);
@@ -438,17 +356,11 @@ fn test_inspect_storage_keys() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let user = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     // Get storage keys
     let balance_key = client.inspect_balance_key(&user);
@@ -473,15 +385,9 @@ fn test_symbolic_instance_storage_keys() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let _client = FeaturesContractClient::new(env, &contract_id);
 
     // Verify Instance storage uses symbolic keys (default mode)
     env.as_contract(&contract_id, || {
@@ -507,17 +413,11 @@ fn test_hashed_persistent_storage_keys() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let user = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     client.mint(&user, &1000);
 
@@ -542,18 +442,12 @@ fn test_custom_short_key_prefix() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let from = Address::generate(env);
     let spender = Address::generate(env);
 
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     client.approve(&from, &spender, &100);
 
@@ -573,15 +467,9 @@ fn test_symbolic_override_in_governance() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
-    client.init(
-        &admin,
-        &String::from_str(env, "Token"),
-        &String::from_str(env, "TKN"),
-    );
+    let contract_id = register_default(env, &admin);
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     client.record_event(&1, &String::from_str(env, "Test event"));
 
@@ -606,20 +494,21 @@ fn test_full_token_lifecycle() {
     let env = &Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register(FeaturesContract, ());
-    let client = FeaturesContractClient::new(env, &contract_id);
-
     let admin = Address::generate(env);
     let alice = Address::generate(env);
     let bob = Address::generate(env);
     let charlie = Address::generate(env);
 
-    // 1. Initialize
-    client.init(
-        &admin,
-        &String::from_str(env, "Test Token"),
-        &String::from_str(env, "TEST"),
+    // 1. Initialize via __constructor
+    let contract_id = env.register(
+        FeaturesContract,
+        (
+            &admin,
+            String::from_str(env, "Test Token"),
+            String::from_str(env, "TEST"),
+        ),
     );
+    let client = FeaturesContractClient::new(env, &contract_id);
 
     // 2. Mint to users
     // alice: 1000, bob: 500, total: 1500
@@ -651,7 +540,7 @@ fn test_full_token_lifecycle() {
     assert!(client.is_frozen(&alice));
     let result = client.try_transfer(&alice, &bob, &50);
     assert_eq!(result, Err(Ok(Error::AccountFrozen)));
-    
+
     // Balances should be unchanged after failed transfer
     assert_eq!(client.get_balance(&alice), 950);
     assert_eq!(client.get_balance(&bob), 550);

--- a/soroban-sdk-tools/tests/auth_tests.rs
+++ b/soroban-sdk-tools/tests/auth_tests.rs
@@ -250,10 +250,13 @@ fn test_side_by_side_multi_user_auth() {
     // ─────────────────────────────────────────────────────────────────────────
     soroban_sdk_tools::auth::setup_mock_auth(
         env,
-        &contract_id,
-        "atomic_swap",
-        (alice, 150_i128, bob, 250_i128),
         &[alice, bob], // Both users authorize
+        soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "atomic_swap",
+            args: (alice, 150_i128, bob, 250_i128).into_val(env),
+            sub_invokes: &[],
+        },
     );
     client.atomic_swap(alice, &150, bob, &250);
 }
@@ -423,10 +426,13 @@ fn test_multi_signer_vault_withdrawal() {
     // Using the setup_mock_auth helper for multi-user auth
     soroban_sdk_tools::auth::setup_mock_auth(
         env,
-        &contract_id,
-        "withdraw",
-        (authorizers, recipient, 500_i128),
         &[signer1, signer2],
+        soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "withdraw",
+            args: (authorizers, recipient, 500_i128).into_val(env),
+            sub_invokes: &[],
+        },
     );
 
     client.withdraw(authorizers, recipient, &500);
@@ -446,10 +452,13 @@ fn test_atomic_two_party_swap() {
     // Use setup_mock_auth to set up auth for BOTH parties
     soroban_sdk_tools::auth::setup_mock_auth(
         env,
-        &contract_id,
-        "atomic_swap",
-        (alice, 100_i128, bob, 200_i128),
         &[alice, bob],
+        soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "atomic_swap",
+            args: (alice, 100_i128, bob, 200_i128).into_val(env),
+            sub_invokes: &[],
+        },
     );
 
     client.atomic_swap(alice, &100, bob, &200);
@@ -469,10 +478,13 @@ fn test_three_party_swap() {
     // All three parties must authorize
     soroban_sdk_tools::auth::setup_mock_auth(
         env,
-        &contract_id,
-        "three_way_swap",
-        (party_a, party_b, party_c, 100_i128),
         &[party_a, party_b, party_c],
+        soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "three_way_swap",
+            args: (party_a, party_b, party_c, 100_i128).into_val(env),
+            sub_invokes: &[],
+        },
     );
 
     client.three_way_swap(party_a, party_b, party_c, &100);
@@ -503,10 +515,13 @@ fn test_insufficient_signers_fails() {
 
     soroban_sdk_tools::auth::setup_mock_auth(
         env,
-        &contract_id,
-        "withdraw",
-        (authorizers, recipient, 500_i128),
         &[signer1],
+        soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "withdraw",
+            args: (authorizers, recipient, 500_i128).into_val(env),
+            sub_invokes: &[],
+        },
     );
 
     // This should fail because we need 2 signers
@@ -541,7 +556,16 @@ fn test_setup_mock_auth_single_authorizer() {
     let user = &Address::generate(env);
 
     // Use setup_mock_auth with single authorizer
-    soroban_sdk_tools::auth::setup_mock_auth(env, &contract_id, "action", (user,), &[user]);
+    soroban_sdk_tools::auth::setup_mock_auth(
+        env,
+        &[user],
+        soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "action",
+            args: (user,).into_val(env),
+            sub_invokes: &[],
+        },
+    );
 
     client.action(user);
 }
@@ -558,10 +582,13 @@ fn test_setup_mock_auth_multiple_authorizers() {
     // Use setup_mock_auth with multiple authorizers
     soroban_sdk_tools::auth::setup_mock_auth(
         env,
-        &contract_id,
-        "dual_action",
-        (user1, user2),
         &[user1, user2],
+        soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "dual_action",
+            args: (user1, user2).into_val(env),
+            sub_invokes: &[],
+        },
     );
 
     client.dual_action(user1, user2);
@@ -578,10 +605,13 @@ fn test_setup_mock_auth_empty_authorizers_is_noop() {
     // Empty authorizers should be a no-op (doesn't set up any mock auth)
     soroban_sdk_tools::auth::setup_mock_auth(
         env,
-        &contract_id,
-        "action",
-        (user.clone(),),
         &[], // No authorizers
+        soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "action",
+            args: (user.clone(),).into_val(env),
+            sub_invokes: &[],
+        },
     );
 
     // This should fail because no auth was set up
@@ -631,10 +661,13 @@ fn test_setup_mock_auth_wrong_authorizer_fails() {
     // Set up auth for wrong user
     soroban_sdk_tools::auth::setup_mock_auth(
         env,
-        &contract_id,
-        "action",
-        (user,),
         &[wrong_user], // Wrong authorizer!
+        soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "action",
+            args: (user,).into_val(env),
+            sub_invokes: &[],
+        },
     );
 
     // This should fail because user != wrong_user

--- a/soroban-sdk-tools/tests/real_auth_tests.rs
+++ b/soroban-sdk-tools/tests/real_auth_tests.rs
@@ -3,8 +3,8 @@
 //! Tests Ed25519, Secp256k1, Secp256r1 key types using the Signer trait
 //! and CallBuilder.sign() pattern.
 
-use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{contract, contractimpl, Address, Env};
+use soroban_sdk::testutils::{Address as _, MockAuthInvoke};
+use soroban_sdk::{contract, contractimpl, Address, Env, IntoVal};
 use soroban_sdk_tools::{Keypair, Secp256k1Keypair, Secp256r1Keypair, Signer};
 
 // Import the token contract WASM
@@ -67,10 +67,13 @@ fn test_real_auth_ed25519_multi_signer() {
 
     soroban_sdk_tools::setup_real_auth(
         &env,
-        &contract_id,
-        "dual_action",
-        (alice.address().clone(), bob.address().clone()),
         &[&alice, &bob],
+        MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "dual_action",
+            args: (alice.address().clone(), bob.address().clone()).into_val(&env),
+            sub_invokes: &[],
+        },
     );
 
     client.dual_action(alice.address(), bob.address());
@@ -89,10 +92,13 @@ fn test_real_auth_ed25519_wrong_signer_fails() {
     // Sign with wrong keypair - should fail
     soroban_sdk_tools::setup_real_auth(
         &env,
-        &contract_id,
-        "action",
-        (alice.address().clone(),),
-        &[&wrong],
+        &[&wrong as &dyn Signer],
+        MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "action",
+            args: (alice.address().clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
     );
 
     client.action(alice.address());
@@ -112,10 +118,13 @@ fn test_real_auth_secp256k1_single() {
 
     soroban_sdk_tools::setup_real_auth(
         &env,
-        &contract_id,
-        "action",
-        (alice_k1.address().clone(),),
-        &[&alice_k1],
+        &[&alice_k1 as &dyn Signer],
+        MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "action",
+            args: (alice_k1.address().clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
     );
 
     client.action(alice_k1.address());
@@ -156,10 +165,13 @@ fn test_real_auth_secp256k1_wrong_key_fails() {
     // Sign with wrong key - should fail
     soroban_sdk_tools::setup_real_auth(
         &env,
-        &contract_id,
-        "action",
-        (alice_k1.address().clone(),),
-        &[&wrong_k1],
+        &[&wrong_k1 as &dyn Signer],
+        MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "action",
+            args: (alice_k1.address().clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
     );
 
     client.action(alice_k1.address());
@@ -179,10 +191,13 @@ fn test_real_auth_secp256r1_single() {
 
     soroban_sdk_tools::setup_real_auth(
         &env,
-        &contract_id,
-        "action",
-        (alice_r1.address().clone(),),
-        &[&alice_r1],
+        &[&alice_r1 as &dyn Signer],
+        MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "action",
+            args: (alice_r1.address().clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
     );
 
     client.action(alice_r1.address());
@@ -222,10 +237,13 @@ fn test_real_auth_secp256r1_wrong_key_fails() {
 
     soroban_sdk_tools::setup_real_auth(
         &env,
-        &contract_id,
-        "action",
-        (alice_r1.address().clone(),),
-        &[&wrong_r1],
+        &[&wrong_r1 as &dyn Signer],
+        MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "action",
+            args: (alice_r1.address().clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
     );
 
     client.action(alice_r1.address());
@@ -247,10 +265,13 @@ fn test_real_auth_mixed_signers() {
     // Both an Ed25519 and a Secp256k1 signer authorize the same call
     soroban_sdk_tools::setup_real_auth(
         &env,
-        &contract_id,
-        "dual_action",
-        (alice.address().clone(), bob_k1.address().clone()),
-        &[&alice, &bob_k1],
+        &[&alice as &dyn Signer, &bob_k1 as &dyn Signer],
+        MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "dual_action",
+            args: (alice.address().clone(), bob_k1.address().clone()).into_val(&env),
+            sub_invokes: &[],
+        },
     );
 
     client.dual_action(alice.address(), bob_k1.address());
@@ -272,10 +293,13 @@ fn test_setup_real_auth_standalone() {
     // Direct function usage without CallBuilder
     soroban_sdk_tools::setup_real_auth(
         &env,
-        &contract_id,
-        "transfer",
-        (alice.address().clone(), bob.clone(), 300_i128),
-        &[&alice],
+        &[&alice as &dyn Signer],
+        MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "transfer",
+            args: (alice.address().clone(), bob.clone(), 300_i128).into_val(&env),
+            sub_invokes: &[],
+        },
     );
     client.transfer(alice.address(), &bob, &300);
 


### PR DESCRIPTION
## Summary
- `examples/features/src/test.rs` called `client.init(...)` but the contract uses `__constructor`. Moved init args into `env.register(FeaturesContract, (&admin, name, symbol))`, added a `register_default` helper, and dropped `test_already_initialized_error` (can't invoke `__constructor` twice).
- `auth_tests.rs` and `real_auth_tests.rs` used the old 5-arg `setup_mock_auth` / `setup_real_auth` signatures. Updated all call sites to the new `(env, &authorizers/signers, MockAuthInvoke { ... })` form.
- Single-element typed signer slices need explicit `as &dyn Signer` casts since Rust can't auto-coerce `&[&Secp256k1Keypair; 1]` to `&[&dyn Signer]`.

## Test plan
- [x] `cargo t` — 203 tests run, 203 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)