### PR TITLE
fix: import IntoVal in upgradeable_contract test

### DIFF
--- a/examples/soroban-examples/upgradeable_contract/old_contract/src/test.rs
+++ b/examples/soroban-examples/upgradeable_contract/old_contract/src/test.rs
@@ -4,7 +4,7 @@ extern crate std;
 
 use soroban_sdk::{
     testutils::{Address as _, MockAuthInvoke},
-    Address, BytesN, Env, Executable,
+    Address, BytesN, Env, Executable, IntoVal,
 };
 
 use crate::{UpgradeableContract, UpgradeableContractClient};


### PR DESCRIPTION
## Summary
Fixes a compile error in BlaineHeffron/soroban-sdk-tools#31. The `upgradeable_contract/old_contract/src/test.rs` file calls `.into_val(&env)` on the `args` tuple but never imports the `IntoVal` trait, so `cargo test` in `examples/soroban-examples/` fails with E0599.

## Test plan
- [x] `cd examples/soroban-examples && cargo t` — 89 tests run, 89 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)