### PR TITLE
Add scerr numbered range support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ pub enum TokenError {
 }
 ```
 
+You can also anchor variants at explicit numeric boundaries when you want grouped native codes, and `#[scerr]` will keep nested composition dense internally:
+
+```rust
+#[scerr]
+pub enum ContractErrors {
+    UnexpectedError = 0,
+
+    UnauthorizedSigner = 100,
+    WrongVoter,
+
+    InvalidKey = 200,
+    ProjectAlreadyExist,
+
+    AlreadyVoted = 400,
+    ProposalVotingTime,
+}
+```
+
 For cross-contract calls, `#[transparent]` propagates errors in the same WASM via `?`, and `#[from_contract_client]` handles `try_` calls via `??`:
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can also anchor variants at explicit numeric boundaries when you want groupe
 ```rust
 #[scerr]
 pub enum ContractErrors {
-    UnexpectedError = 0,
+    UnexpectedError = 1,
 
     UnauthorizedSigner = 100,
     WrongVoter,

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ There's a Map and Item variant for each durability: `PersistentMap<K,V>` / `Pers
 
 ## Error handling
 
-`#[scerr]` generates a `#[contracterror]` enum with sequential codes and doc-comment descriptions:
+`#[scerr]` generates a `#[contracterror]` enum with doc-comment descriptions and generated codes:
 
 ```rust
 use soroban_sdk_tools::scerr;
@@ -121,7 +121,7 @@ pub enum AppError {
 }
 ```
 
-Codes are assigned sequentially and the WASM spec comes out fully flattened, so your TypeScript bindings see every variant without gaps. See [error docs](https://docs.rs/soroban-sdk-tools/latest/soroban_sdk_tools/error/) for the composition rules.
+By default the generated codes are sequential. If you add explicit anchors in a basic enum, those native codes are preserved while composition and the WASM spec still flatten densely. See [error docs](https://docs.rs/soroban-sdk-tools/latest/soroban_sdk_tools/error/) for the composition rules.
 
 ## Contract imports
 

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -163,6 +163,48 @@ pub fn safe_div_with(
 
       <section class="section comparison-section reveal">
         <div class="section-heading">
+          <p class="eyebrow">Numbered ranges</p>
+          <h2>Same grouped native codes, less manual bookkeeping</h2>
+        </div>
+        <div class="comparison-grid">
+          <article class="code-panel">
+            <h3>Anchored basic enum</h3>
+            <pre><code class="language-rust">#[scerr]
+pub enum ContractErrors {
+    UnexpectedError = 0,
+
+    UnauthorizedSigner = 100,
+    WrongVoter,
+    MaintainerNotDomainOwner,
+
+    InvalidKey = 200,
+    ProjectAlreadyExist,
+
+    AlreadyVoted = 400,
+    ProposalVotingTime,
+}</code></pre>
+          </article>
+          <article class="code-panel">
+            <h3>Wrapped later</h3>
+            <pre><code class="language-rust">#[scerr]
+pub enum AppError {
+    Unauthorized,
+
+    #[transparent]
+    Contract(#[from] ContractErrors),
+}
+
+// External/native codes stay 0, 100, 101, 200, 400...
+// Inner composition still uses a dense sequence internally.</code></pre>
+          </article>
+        </div>
+        <p class="comparison-note">
+          Use explicit discriminants when downstream consumers care about stable grouped ranges. <code>#[scerr]</code> still keeps nested composition dense, so wrappers and imported errors continue to work.
+        </p>
+      </section>
+
+      <section class="section comparison-section reveal">
+        <div class="section-heading">
           <p class="eyebrow">Auth testing</p>
           <h2>Same token transfer, less auth setup</h2>
         </div>

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -171,7 +171,7 @@ pub fn safe_div_with(
             <h3>Anchored basic enum</h3>
             <pre><code class="language-rust">#[scerr]
 pub enum ContractErrors {
-    UnexpectedError = 0,
+    UnexpectedError = 1,
 
     UnauthorizedSigner = 100,
     WrongVoter,

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -194,7 +194,7 @@ pub enum AppError {
     Contract(#[from] ContractErrors),
 }
 
-// External/native codes stay 0, 100, 101, 200, 400...
+// External/native codes stay 1, 100, 101, 200, 400...
 // Inner composition still uses a dense sequence internally.</code></pre>
           </article>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -114,8 +114,8 @@ pub struct VaultState {
 pub enum VaultError {
     Unauthorized = 100,
     WrongSigner,
-    #[transparent]
-    Token(#[from] TokenError),
+    ProposalClosed = 400,
+    AlreadySettled,
 }
 
 #[test]

--- a/docs/index.html
+++ b/docs/index.html
@@ -112,7 +112,8 @@ pub struct VaultState {
 
 #[scerr]
 pub enum VaultError {
-    Unauthorized,
+    Unauthorized = 100,
+    WrongSigner,
     #[transparent]
     Token(#[from] TokenError),
 }
@@ -133,7 +134,7 @@ fn transfer_auth_flow() {
               </div>
               <div class="signal">
                 <span class="signal-value">predictable</span>
-                <span class="signal-label">error codes stay sequential without hand maintenance</span>
+                <span class="signal-label">native error ranges stay intentional without breaking composition</span>
               </div>
               <div class="signal">
                 <span class="signal-value">readable</span>
@@ -162,7 +163,7 @@ fn transfer_auth_flow() {
             <p class="card-kicker">Errors</p>
             <h3>Composable errors with predictable codes</h3>
             <p>
-              <code>#[scerr]</code> keeps codes in order and gets the conversion glue out of your way.
+              <code>#[scerr]</code> handles sequential enums and anchored ranges like <code>100-199</code> without extra glue.
             </p>
           </article>
 

--- a/docs/migration.html
+++ b/docs/migration.html
@@ -123,6 +123,7 @@
           <ul>
             <li>Convert one enum at a time.</li>
             <li>Put descriptions in doc comments.</li>
+            <li>Keep explicit anchors like <code>= 100</code> or <code>= 400</code> when you want stable grouped native codes.</li>
             <li>Use <code>#[transparent]</code> with <code>#[from]</code> for same-WASM composition.</li>
             <li>Use <code>#[from_contract_client]</code> for client <code>try_</code> calls.</li>
           </ul>
@@ -131,7 +132,7 @@
         <div class="migration-step">
           <h3>Watch for</h3>
           <ul>
-            <li>Enum order defines the generated codes.</li>
+            <li>Implicit variants continue from the last explicit anchor.</li>
             <li>Cross-contract composition depends on imported error support.</li>
             <li>Keep old numeric mappings documented on live surfaces.</li>
           </ul>

--- a/soroban-sdk-tools-macro/src/error.rs
+++ b/soroban-sdk-tools-macro/src/error.rs
@@ -377,7 +377,7 @@ fn parse_variant_info(variant: &Variant, code: u32) -> syn::Result<VariantInfo> 
 
 /// Assign sequential codes to variants (1, 2, 3, ...).
 /// In root mode, wrapped variants get code 0 (placeholder — actual codes are const-chained).
-/// In basic mode, all variants get sequential codes starting at 1.
+/// In basic mode, implicit variants continue from the last explicit anchor.
 fn assign_codes(data: &DataEnum, mode: ScerrMode) -> syn::Result<Vec<u32>> {
     let mut next_code: u32 = 1;
 
@@ -397,7 +397,9 @@ fn assign_codes(data: &DataEnum, mode: ScerrMode) -> syn::Result<Vec<u32>> {
                     lit: Lit::Int(li), ..
                 }) = expr
                 {
-                    return li.base10_parse::<u32>();
+                    let code = li.base10_parse::<u32>()?;
+                    next_code = code.saturating_add(1);
+                    return Ok(code);
                 } else {
                     return Err(Error::new(
                         expr.span(),
@@ -909,10 +911,14 @@ fn handle_auto_variants(
 fn generate_error_spec_impl(name: &Ident, infos: &[VariantInfo]) -> proc_macro2::TokenStream {
     let unit_variants = infos.iter().filter(|i| i.field_ty().is_none());
 
-    // Basic-mode entries and tree nodes share the same data; build both in one pass.
+    // Basic-mode spec entries report native error codes, while tree nodes keep
+    // a dense sequential layout for root-mode nesting.
     let (spec_entries, tree_nodes): (Vec<_>, Vec<_>) = unit_variants
+        .enumerate()
         .map(|i| {
+            let (idx, i) = i;
             let code = i.code;
+            let seq_code = idx as u32 + 1;
             let variant_name = i.ident.to_string();
             let desc = &i.description;
             (
@@ -923,7 +929,7 @@ fn generate_error_spec_impl(name: &Ident, infos: &[VariantInfo]) -> proc_macro2:
                 },
                 quote! {
                     soroban_sdk_tools::error::SpecNode {
-                        code: #code, name: #variant_name, description: #desc,
+                        code: #seq_code, name: #variant_name, description: #desc,
                         children: &[],
                     }
                 },
@@ -1172,6 +1178,26 @@ fn expand_scerr_basic(
         })
         .collect();
 
+    let to_seq_arms: Vec<_> = infos
+        .iter()
+        .enumerate()
+        .map(|(idx, i)| {
+            let ident = &i.ident;
+            let seq = idx as u32;
+            quote! { #name::#ident => #seq }
+        })
+        .collect();
+
+    let from_seq_arms: Vec<_> = infos
+        .iter()
+        .enumerate()
+        .map(|(idx, i)| {
+            let ident = &i.ident;
+            let seq = idx as u32;
+            quote! { #seq => Some(#name::#ident) }
+        })
+        .collect();
+
     // Generate ContractErrorSpec implementation
     let spec_impl = generate_error_spec_impl(name, infos);
 
@@ -1196,10 +1222,15 @@ fn expand_scerr_basic(
 
         impl soroban_sdk_tools::error::SequentialError for #name {
             fn to_seq(&self) -> u32 {
-                *self as u32 - 1
+                match self {
+                    #(#to_seq_arms,)*
+                }
             }
             fn from_seq(seq: u32) -> Option<Self> {
-                <Self as soroban_sdk_tools::error::ContractError>::from_code(seq + 1)
+                match seq {
+                    #(#from_seq_arms,)*
+                    _ => None,
+                }
             }
         }
 
@@ -1307,5 +1338,28 @@ mod tests {
             variants: item.variants,
         };
         assert_eq!(detect_mode(&data), ScerrMode::Root);
+    }
+
+    #[test]
+    fn test_assign_codes_basic_respects_explicit_anchors() {
+        let item: syn::ItemEnum = parse_quote! {
+            enum Test {
+                UnexpectedError = 0,
+                UnauthorizedSigner = 100,
+                WrongVoter,
+                InvalidKey = 200,
+                ProjectAlreadyExist,
+                AlreadyVoted = 400,
+                ProposalVotingTime,
+            }
+        };
+        let data = DataEnum {
+            enum_token: item.enum_token,
+            brace_token: item.brace_token,
+            variants: item.variants,
+        };
+
+        let codes = assign_codes(&data, ScerrMode::Basic).unwrap();
+        assert_eq!(codes, vec![0, 100, 101, 200, 201, 400, 401]);
     }
 }

--- a/soroban-sdk-tools-macro/src/error.rs
+++ b/soroban-sdk-tools-macro/src/error.rs
@@ -48,9 +48,11 @@
 //!
 //! ## Architecture
 //!
-//! Error codes are assigned **sequentially** starting at 1. When a variant wraps another
-//! error type (via `#[transparent]` or `#[from_contract_client]`), the inner type's variants
-//! are flattened into the sequential range at their position using const-chaining.
+//! Error codes are sequential by default, but basic-mode enums may use explicit
+//! discriminants to preserve native ranges. When a variant wraps another error
+//! type (via `#[transparent]` or `#[from_contract_client]`), the inner type's
+//! variants are flattened into a dense sequential range at their position using
+//! const-chaining.
 //!
 //! For example, if `MathError` has 2 variants:
 //! - `Unauthorized = 1`
@@ -398,7 +400,13 @@ fn assign_codes(data: &DataEnum, mode: ScerrMode) -> syn::Result<Vec<u32>> {
                 }) = expr
                 {
                     let code = li.base10_parse::<u32>()?;
-                    next_code = code.saturating_add(1);
+                    next_code = code.checked_add(1).ok_or_else(|| {
+                        Error::new(
+                            li.span(),
+                            "Explicit discriminant cannot be u32::MAX because implicit variants \
+                             would overflow the code space",
+                        )
+                    })?;
                     return Ok(code);
                 } else {
                     return Err(Error::new(
@@ -915,8 +923,7 @@ fn generate_error_spec_impl(name: &Ident, infos: &[VariantInfo]) -> proc_macro2:
     // a dense sequential layout for root-mode nesting.
     let (spec_entries, tree_nodes): (Vec<_>, Vec<_>) = unit_variants
         .enumerate()
-        .map(|i| {
-            let (idx, i) = i;
+        .map(|(idx, i)| {
             let code = i.code;
             let seq_code = idx as u32 + 1;
             let variant_name = i.ident.to_string();
@@ -1361,5 +1368,50 @@ mod tests {
 
         let codes = assign_codes(&data, ScerrMode::Basic).unwrap();
         assert_eq!(codes, vec![0, 100, 101, 200, 201, 400, 401]);
+    }
+
+    #[test]
+    fn test_assign_codes_root_rejects_explicit_discriminant() {
+        let item: syn::ItemEnum = parse_quote! {
+            enum Test {
+                A = 100,
+                #[transparent]
+                B(SomeError),
+            }
+        };
+        let data = DataEnum {
+            enum_token: item.enum_token,
+            brace_token: item.brace_token,
+            variants: item.variants,
+        };
+
+        let err = assign_codes(&data, ScerrMode::Root).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Explicit discriminants are not allowed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_assign_codes_rejects_u32_max_anchor() {
+        let item: syn::ItemEnum = parse_quote! {
+            enum Test {
+                Maxed = 4294967295,
+                Next,
+            }
+        };
+        let data = DataEnum {
+            enum_token: item.enum_token,
+            brace_token: item.brace_token,
+            variants: item.variants,
+        };
+
+        let err = assign_codes(&data, ScerrMode::Basic).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Explicit discriminant cannot be u32::MAX"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/soroban-sdk-tools/src/error.rs
+++ b/soroban-sdk-tools/src/error.rs
@@ -30,9 +30,10 @@ pub trait ContractError: Sized {
 /// any off-by-one arithmetic. Types implementing this trait can be used as
 /// inner types in `#[transparent]` and `#[from_contract_client]` variants.
 ///
-/// For `#[scerr]` types, `to_seq()` returns `into_code() - 1` (since codes
-/// start at 1). For `contractimport!` types, the mapping is generated from
-/// the variant order regardless of native error codes.
+/// For `#[scerr]` and `contractimport!` types, this mapping is generated from
+/// variant order regardless of native error codes. This keeps composition dense
+/// even when a basic `#[scerr]` enum uses explicit discriminants such as
+/// `100`, `200`, or `400`.
 pub trait SequentialError: Sized {
     /// Convert this error to a 0-based sequential index in `[0, TOTAL_CODES)`.
     fn to_seq(&self) -> u32;

--- a/soroban-sdk-tools/src/error.rs
+++ b/soroban-sdk-tools/src/error.rs
@@ -1,10 +1,11 @@
 //! Error handling utilities for Soroban contracts.
 //!
 //! Provides traits and helper types for composable error handling
-//! with the `#[scerr]` macro. Error codes are assigned sequentially
-//! starting at 1, with wrapped inner types flattened at their position
-//! via const-chaining. The `Aborted` variant always uses code 0, and
-//! the `UnknownError` sentinel always uses [`UNKNOWN_ERROR_CODE`].
+//! with the `#[scerr]` macro. Basic enums use sequential codes by default,
+//! but may preserve explicit numeric anchors. Wrapped inner types are
+//! flattened into a dense sequential space via const-chaining. The `Aborted`
+//! variant always uses code 0, and the `UnknownError` sentinel always uses
+//! [`UNKNOWN_ERROR_CODE`].
 
 // Re-export contracterror for users
 pub use soroban_sdk::contracterror;

--- a/soroban-sdk-tools/tests/error_integration_tests.rs
+++ b/soroban-sdk-tools/tests/error_integration_tests.rs
@@ -1015,6 +1015,29 @@ pub enum StorageError {
     QuotaExceeded,
 }
 
+#[scerr]
+pub enum GroupedRangeError {
+    UnexpectedError = 0,
+
+    UnauthorizedSigner = 100,
+    WrongVoter,
+    MaintainerNotDomainOwner,
+
+    InvalidKey = 200,
+    ProjectAlreadyExist,
+
+    AlreadyVoted = 400,
+    ProposalVotingTime,
+}
+
+#[scerr]
+pub enum GroupedRangeCallerError {
+    Unauthorized,
+
+    #[transparent]
+    Inner(#[from] GroupedRangeError),
+}
+
 #[contract]
 pub struct StorageContract;
 
@@ -1368,6 +1391,7 @@ fn basic_mode_total_codes() {
     assert_eq!(LogicError::TOTAL_CODES, 2);
     assert_eq!(StandardError::TOTAL_CODES, 3);
     assert_eq!(StorageError::TOTAL_CODES, 3);
+    assert_eq!(GroupedRangeError::TOTAL_CODES, 8);
 }
 
 #[test]
@@ -1381,6 +1405,80 @@ fn basic_mode_spec_tree() {
     assert_eq!(tree[0].name, "DivisionByZero");
     assert_eq!(tree[1].code, 2);
     assert_eq!(tree[1].name, "NegativeInput");
+}
+
+#[test]
+fn basic_mode_explicit_ranges_keep_native_codes() {
+    use soroban_sdk_tools::error::SequentialError;
+
+    assert_eq!(GroupedRangeError::UnexpectedError.into_code(), 0);
+    assert_eq!(GroupedRangeError::UnauthorizedSigner.into_code(), 100);
+    assert_eq!(GroupedRangeError::WrongVoter.into_code(), 101);
+    assert_eq!(GroupedRangeError::MaintainerNotDomainOwner.into_code(), 102);
+    assert_eq!(GroupedRangeError::InvalidKey.into_code(), 200);
+    assert_eq!(GroupedRangeError::ProjectAlreadyExist.into_code(), 201);
+    assert_eq!(GroupedRangeError::AlreadyVoted.into_code(), 400);
+    assert_eq!(GroupedRangeError::ProposalVotingTime.into_code(), 401);
+
+    assert_eq!(
+        <GroupedRangeError as ContractError>::from_code(0),
+        Some(GroupedRangeError::UnexpectedError)
+    );
+    assert_eq!(
+        <GroupedRangeError as ContractError>::from_code(100),
+        Some(GroupedRangeError::UnauthorizedSigner)
+    );
+    assert_eq!(
+        <GroupedRangeError as ContractError>::from_code(401),
+        Some(GroupedRangeError::ProposalVotingTime)
+    );
+    assert_eq!(<GroupedRangeError as ContractError>::from_code(1), None);
+
+    assert_eq!(GroupedRangeError::UnexpectedError.to_seq(), 0);
+    assert_eq!(GroupedRangeError::UnauthorizedSigner.to_seq(), 1);
+    assert_eq!(GroupedRangeError::WrongVoter.to_seq(), 2);
+    assert_eq!(GroupedRangeError::MaintainerNotDomainOwner.to_seq(), 3);
+    assert_eq!(GroupedRangeError::InvalidKey.to_seq(), 4);
+    assert_eq!(GroupedRangeError::ProjectAlreadyExist.to_seq(), 5);
+    assert_eq!(GroupedRangeError::AlreadyVoted.to_seq(), 6);
+    assert_eq!(GroupedRangeError::ProposalVotingTime.to_seq(), 7);
+
+    assert_eq!(
+        GroupedRangeError::from_seq(0),
+        Some(GroupedRangeError::UnexpectedError)
+    );
+    assert_eq!(
+        GroupedRangeError::from_seq(6),
+        Some(GroupedRangeError::AlreadyVoted)
+    );
+    assert_eq!(GroupedRangeError::from_seq(8), None);
+}
+
+#[test]
+fn basic_mode_explicit_ranges_spec_metadata() {
+    let entries = GroupedRangeError::SPEC_ENTRIES;
+    assert_eq!(entries.len(), 8);
+    assert_eq!(entries[0].code, 0);
+    assert_eq!(entries[1].code, 100);
+    assert_eq!(entries[2].code, 101);
+    assert_eq!(entries[3].code, 102);
+    assert_eq!(entries[4].code, 200);
+    assert_eq!(entries[5].code, 201);
+    assert_eq!(entries[6].code, 400);
+    assert_eq!(entries[7].code, 401);
+
+    let tree = GroupedRangeError::SPEC_TREE;
+    assert_eq!(tree.len(), 8);
+    assert_eq!(tree[0].code, 1);
+    assert_eq!(tree[1].code, 2);
+    assert_eq!(tree[2].code, 3);
+    assert_eq!(tree[3].code, 4);
+    assert_eq!(tree[4].code, 5);
+    assert_eq!(tree[5].code, 6);
+    assert_eq!(tree[6].code, 7);
+    assert_eq!(tree[7].code, 8);
+    assert_eq!(tree[0].name, "UnexpectedError");
+    assert_eq!(tree[6].name, "AlreadyVoted");
 }
 
 #[test]
@@ -1413,6 +1511,43 @@ fn root_mode_total_codes() {
     // MixedFccError: NotPermitted=1, InvalidConfig=2, MathOp[2]=3-4,
     // StandardOp[3]=5-7, StorageOp[3]=8-10, LogicOp[2]=11-12
     assert_eq!(MixedFccError::TOTAL_CODES, 12);
+
+    // GroupedRangeCallerError: Unauthorized=1, Inner[8]=2-9
+    assert_eq!(GroupedRangeCallerError::TOTAL_CODES, 9);
+}
+
+#[test]
+fn root_mode_wraps_basic_explicit_ranges_sequentially() {
+    assert_eq!(GroupedRangeCallerError::Unauthorized.into_code(), 1);
+    assert_eq!(
+        GroupedRangeCallerError::Inner(GroupedRangeError::UnexpectedError).into_code(),
+        2
+    );
+    assert_eq!(
+        GroupedRangeCallerError::Inner(GroupedRangeError::UnauthorizedSigner).into_code(),
+        3
+    );
+    assert_eq!(
+        GroupedRangeCallerError::Inner(GroupedRangeError::AlreadyVoted).into_code(),
+        8
+    );
+    assert_eq!(
+        GroupedRangeCallerError::Inner(GroupedRangeError::ProposalVotingTime).into_code(),
+        9
+    );
+
+    assert_eq!(
+        <GroupedRangeCallerError as ContractError>::from_code(2),
+        Some(GroupedRangeCallerError::Inner(
+            GroupedRangeError::UnexpectedError
+        ))
+    );
+    assert_eq!(
+        <GroupedRangeCallerError as ContractError>::from_code(9),
+        Some(GroupedRangeCallerError::Inner(
+            GroupedRangeError::ProposalVotingTime
+        ))
+    );
 }
 
 #[test]

--- a/soroban-sdk-tools/tests/error_integration_tests.rs
+++ b/soroban-sdk-tools/tests/error_integration_tests.rs
@@ -1017,7 +1017,7 @@ pub enum StorageError {
 
 #[scerr]
 pub enum GroupedRangeError {
-    UnexpectedError = 0,
+    UnexpectedError = 1,
 
     UnauthorizedSigner = 100,
     WrongVoter,
@@ -1411,7 +1411,7 @@ fn basic_mode_spec_tree() {
 fn basic_mode_explicit_ranges_keep_native_codes() {
     use soroban_sdk_tools::error::SequentialError;
 
-    assert_eq!(GroupedRangeError::UnexpectedError.into_code(), 0);
+    assert_eq!(GroupedRangeError::UnexpectedError.into_code(), 1);
     assert_eq!(GroupedRangeError::UnauthorizedSigner.into_code(), 100);
     assert_eq!(GroupedRangeError::WrongVoter.into_code(), 101);
     assert_eq!(GroupedRangeError::MaintainerNotDomainOwner.into_code(), 102);
@@ -1421,7 +1421,7 @@ fn basic_mode_explicit_ranges_keep_native_codes() {
     assert_eq!(GroupedRangeError::ProposalVotingTime.into_code(), 401);
 
     assert_eq!(
-        <GroupedRangeError as ContractError>::from_code(0),
+        <GroupedRangeError as ContractError>::from_code(1),
         Some(GroupedRangeError::UnexpectedError)
     );
     assert_eq!(
@@ -1432,7 +1432,7 @@ fn basic_mode_explicit_ranges_keep_native_codes() {
         <GroupedRangeError as ContractError>::from_code(401),
         Some(GroupedRangeError::ProposalVotingTime)
     );
-    assert_eq!(<GroupedRangeError as ContractError>::from_code(1), None);
+    assert_eq!(<GroupedRangeError as ContractError>::from_code(2), None);
 
     assert_eq!(GroupedRangeError::UnexpectedError.to_seq(), 0);
     assert_eq!(GroupedRangeError::UnauthorizedSigner.to_seq(), 1);
@@ -1458,7 +1458,7 @@ fn basic_mode_explicit_ranges_keep_native_codes() {
 fn basic_mode_explicit_ranges_spec_metadata() {
     let entries = GroupedRangeError::SPEC_ENTRIES;
     assert_eq!(entries.len(), 8);
-    assert_eq!(entries[0].code, 0);
+    assert_eq!(entries[0].code, 1);
     assert_eq!(entries[1].code, 100);
     assert_eq!(entries[2].code, 101);
     assert_eq!(entries[3].code, 102);

--- a/soroban-sdk-tools/tests/error_integration_tests.rs
+++ b/soroban-sdk-tools/tests/error_integration_tests.rs
@@ -1039,6 +1039,39 @@ pub enum GroupedRangeCallerError {
 }
 
 #[contract]
+pub struct GroupedRangeContract;
+
+#[contractimpl]
+impl GroupedRangeContract {
+    pub fn fail_proposal_time() -> Result<(), GroupedRangeError> {
+        Err(GroupedRangeError::ProposalVotingTime)
+    }
+}
+
+#[scerr]
+pub enum GroupedRangeFccError {
+    Unauthorized,
+
+    #[from_contract_client]
+    Inner(GroupedRangeError),
+}
+
+#[contract]
+pub struct GroupedRangeFccContract;
+
+#[contractimpl]
+impl GroupedRangeFccContract {
+    pub fn call_grouped_fail(
+        env: Env,
+        grouped_id: Address,
+    ) -> Result<(), GroupedRangeFccError> {
+        let client = GroupedRangeContractClient::new(&env, &grouped_id);
+        client.try_fail_proposal_time()??;
+        Ok(())
+    }
+}
+
+#[contract]
 pub struct StorageContract;
 
 #[contractimpl]
@@ -1545,6 +1578,41 @@ fn root_mode_wraps_basic_explicit_ranges_sequentially() {
     assert_eq!(
         <GroupedRangeCallerError as ContractError>::from_code(9),
         Some(GroupedRangeCallerError::Inner(
+            GroupedRangeError::ProposalVotingTime
+        ))
+    );
+}
+
+fn setup_grouped_range_contract(env: &Env) -> Address {
+    env.register(GroupedRangeContract, ())
+}
+
+fn setup_grouped_range_fcc_contract(env: &Env) -> Address {
+    env.register(GroupedRangeFccContract, ())
+}
+
+#[test]
+fn root_mode_fcc_wraps_basic_explicit_ranges_sequentially() {
+    let env = Env::default();
+    let grouped_id = setup_grouped_range_contract(&env);
+    let caller_id = setup_grouped_range_fcc_contract(&env);
+    let client = GroupedRangeFccContractClient::new(&env, &caller_id);
+
+    let result = client.try_call_grouped_fail(&grouped_id);
+    assert!(result.is_err());
+
+    let err = result.err().unwrap();
+    let decoded: GroupedRangeFccError = err.expect("should be a contract error");
+    assert_eq!(
+        decoded,
+        GroupedRangeFccError::Inner(GroupedRangeError::ProposalVotingTime)
+    );
+
+    let code = GroupedRangeFccError::Inner(GroupedRangeError::ProposalVotingTime).into_code();
+    assert_eq!(code, 9);
+    assert_eq!(
+        GroupedRangeFccError::from_code(code),
+        Some(GroupedRangeFccError::Inner(
             GroupedRangeError::ProposalVotingTime
         ))
     );


### PR DESCRIPTION
## Summary
- support explicit discriminant anchors in basic #[scerr] enums
- keep SequentialError and nested root-mode composition dense by variant order
- document numbered range usage in the README and website docs

## Testing
- cargo test -p soroban-sdk-tools --test error_integration_tests
- cargo test -p soroban-sdk-tools-macro